### PR TITLE
Downgrade React Native Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "Curity",
   "license": "Apache",
   "peerDependencies": {
-    "react-native": "0.73.0"
+    "react-native": "0.72.0"
   }
 }


### PR DESCRIPTION
Downgraded react native version to `0.72.0` in the module in order to support react native projects using react-native `0.72.0` or higher