### PR TITLE
Add config switch for disabling TLS checking

### DIFF
--- a/android/src/main/java/io/curity/haapi/react/HaapiConfigurationUtil.kt
+++ b/android/src/main/java/io/curity/haapi/react/HaapiConfigurationUtil.kt
@@ -86,7 +86,7 @@ object HaapiConfigurationUtil {
 
         override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
 
-        override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
     }
 
     private fun URLConnection.disableSslTrustVerification(): URLConnection {


### PR DESCRIPTION
Allow configuration to turn on/off the validation of TLS certificate. Default on