### PR TITLE
Support adding extraRequestParameters and httpHeadersProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # react-native-haapi-module
+
 [![Quality](https://img.shields.io/badge/quality-test-yellow)](https://curity.io/resources/code-examples/status/)
 [![Availability](https://img.shields.io/badge/availability-source-blue)](https://curity.io/resources/code-examples/status/)
 
-This a react-native Native Module that use the Hypermedia Authentication API of the Curity Identity Server. The module utilizes the iOS and Android SDK to perform attestation and communication with the API.
+This a react-native Native Module that use the Hypermedia Authentication API of the Curity Identity Server. The module
+utilizes the iOS and Android SDK to perform attestation and communication with the API.
 
 https://curity.io/product/authentication-service/authentication-api/
 
@@ -12,26 +14,29 @@ https://curity.io/product/authentication-service/authentication-api/
 
 ## Configuration
 
-Parameter Name             | Platform | Required | Default                      | Description
--------------------------- | -------- | -------- | ---------------------------- | -----------------------------------------------------------------------------------------------------
-`appRedirect`              | both     | false    | `app:start`                  | Redirect URI to use in OAuth requests. Needs to be registered in server config
-`keyStoreAlias`            | android  | false    | `haapi-react-native-android` | Keystore alias for keys used in an authentication flow. Only used on Android
-`configurationName`        | ios      | false    | `HaapiModule`                | The name to use for the configuration on iOS. If you are in testing mode and switching environments, make sure that each environment sets a different name
-`clientId`                 | both     | true     |                              | The registered `client_id`
-`baseUri`                  | both     | true     |                              | Base URI of the server. Used for relative redirects.
-`tokenEndpointUri`         | both     | true     |                              | URI of the token endpoint.
-`authorizationEndpointUri` | both     | true     |                              | URI of the authorize endpoint.
-`revocationEndpointUri`    | both     | true     |                              | URI of the revocation endpoint.
-`registrationEndpointUri`  | android  | false    |                              | URI of the registration endpoint. Required if fallback registration should be used.
-`fallback_template_id`     | android  | false    |                              | Name of the template client to be used in fallback. Required if fallback registration should be used.
-`registration_secret`      | android  | false    |                              | Name of the template client to be used in fallback. Required if fallback registration should be used.
-`validateTlsCertificate`   | both     | false    | true                         | If the server TLS certificate should be validated. Set to `false` to accept self signed certificates.
-`acrValues`                | both     | false    | `""`                         | Space separated string to send in authorize request.
-`scope`                    | both     | false    | `""`                         | Space separated string of scopes to request.
+| Parameter Name             | Platform | Required | Default                      | Description                                                                                                                                                |                                                                              
+|----------------------------|----------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `appRedirect`              | both     | false    | `app:start`                  | Redirect URI to use in OAuth requests. Needs to be registered in server config                                                                             |
+| `keyStoreAlias`            | android  | false    | `haapi-react-native-android` | Keystore alias for keys used in an authentication flow. Only used on Android                                                                               |
+| `configurationName`        | ios      | false    | `HaapiModule`                | The name to use for the configuration on iOS. If you are in testing mode and switching environments, make sure that each environment sets a different name |
+| `clientId`                 | both     | true     |                              | The registered `client_id`                                                                                                                                 |
+| `baseUri`                  | both     | true     |                              | Base URI of the server. Used for relative redirects.                                                                                                       |
+| `tokenEndpointUri`         | both     | true     |                              | URI of the token endpoint.                                                                                                                                 |
+| `authorizationEndpointUri` | both     | true     |                              | URI of the authorize endpoint.                                                                                                                             |
+| `revocationEndpointUri`    | both     | true     |                              | URI of the revocation endpoint.                                                                                                                            |
+| `registrationEndpointUri`  | android  | false    |                              | URI of the registration endpoint. Required if fallback registration should be used.                                                                        |
+| `fallback_template_id`     | android  | false    |                              | Name of the template client to be used in fallback. Required if fallback registration should be used.                                                      |
+| `registration_secret`      | android  | false    |                              | Name of the template client to be used in fallback. Required if fallback registration should be used.                                                      |
+| `validateTlsCertificate`   | both     | false    | true                         | If the server TLS certificate should be validated. Set to `false` to accept self signed certificates.                                                      |
+| `acrValues`                | both     | false    | `""`                         | Space separated string to send in authorize request.                                                                                                       |
+| `scope`                    | both     | false    | `""`                         | Space separated string of scopes to request.                                                                                                               |
+| `extraRequestParameters`   | both     | false    | `{}`                         | Map of extra parameters to send in the request to the authorize endpoint.                                                                                  |
+| `extraHttpHeaders`         | both     | false    | `{}`                         | Map of extra http headers to send in all requests to the authentication API.                                                                               |
 
 ## Usage
 
-All functions of the module are async operations. The application may use events produced by the module to drive the authentication flow, or rely on reults return by promises.
+All functions of the module are async operations. The application may use events produced by the module to drive the
+authentication flow, or rely on results return by promises.
 
 ### Load
 
@@ -56,6 +61,8 @@ const haapiConfiguration = {
     "fallback_template_id": "react-native-fallback",
     "registration_secret": "my-good-secret"
     "validateTlsCertificate": true,
+    "extraRequestParameters": {"prompt": "login"},
+    "extraHttpHeaders": {"x-my-good-header": "foobar"}
     "acrValues": ""
 }
 
@@ -65,11 +72,15 @@ HaapiModule.load(HaapiConfiguration).catch(e => {
 
 export default HaapiModule;
 ```
-`load()` man be called multiple times with different configuration, to be able to start authentication flows requesting different `acr` or `scope`.
+
+`load()` may be called multiple times with different configuration, to be able to start authentication flows requesting
+different `acr` or `scope`.
 
 ## Start
 
-After the module has been loaded, the `start()` function may be called. `start()` will setup the communication with HAAPI, perform attestation, and then start emitting events for the application to react on. Receiving events will allow the application to know more about the contents of the current state than if it were to receive the raw HaapiResponse.
+After the module has been loaded, the `start()` function may be called. `start()` will setup the communication with
+HAAPI, perform attestation, and then start emitting events for the application to react on. Receiving events will allow
+the application to know more about the contents of the current state than if it were to receive the raw HaapiResponse.
 The module will follow redirect responses automatically.
 
 ```javascript
@@ -90,7 +101,10 @@ eventEmitter.addListener("EventName", () => {
 ```
 
 ## Navigate
-To follow a link in a HAAPI response, the `navigate(model)` function can be used. `model` is an object conforming to [Link](https://curity.io/docs/haapi-data-model/latest/links.html)
+
+To follow a link in a HAAPI response, the `navigate(model)` function can be used. `model` is an object conforming
+to [Link](https://curity.io/docs/haapi-data-model/latest/links.html)
+
 ```javascript
 try {
     await HaapiModule.navigate(model);
@@ -98,8 +112,12 @@ try {
     console.error(e);
 }
 ```
+
 ## Submit form
-To submit a form in an action, use the submitForm(action, parameters), where `action` is the form to submit, and `parameters` is an object containing the field names and the values to fill the form.
+
+To submit a form in an action, use the submitForm(action, parameters), where `action` is the form to submit,
+and `parameters` is an object containing the field names and the values to fill the form.
+
 ```javascript
 try {
     await HaapiModule.submitForm(action, parameters);
@@ -107,42 +125,54 @@ try {
     console.error(e);
 }
 ```
+
 ## Refresh Access Token
-Refresh the access token using the refresh token. The application may listen to the events `TokenResponse`/`TokenResponseError` for the result of the refresh.
+
+Refresh the access token using the refresh token. The application may listen to the
+events `TokenResponse`/`TokenResponseError` for the result of the refresh.
+
 ```javascript
 HaapiModule.refreshAccessToken(refreshToken);
 ```
+
 ## Log out
+
 Calling log out will revoke the tokens, and close the underlying managers to clear the state.
+
 ```javascript
 HaapiModule.logout().then(/* Remove tokens from state */);
 ```
 
 ## Events
 
-Event Name                 | Emitted when
--------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AuthenticationStep         | An action is required by the user as part of authentication. See [Authentication Step](https://curity.io/docs/haapi-data-model/latest/authentication-step.html)
-AuthenticationSelectorStep | An `AuthenticationStep` with the kind `authenticator-selector` is received. An authenticator selector screen should be be shown to the user.
-ContinueSameStep           | A screen should be shown to the user, containing some information. The only required action by the user is to accept or in some cases cancel. [Continue Same Step](https://curity.io/docs/haapi-data-model/latest/continue-same-step.html)
-PollingStep                | An authentication step that requires polling was received. May contain information for the user for how to proceed authentication out of band. [Polling Step](https://curity.io/docs/haapi-data-model/latest/polling-step.html)
-PollingStepResult          | A poll result was received with the `status` `PENDING`. The application may show new information to the user and continue polling.
-StopPolling                | A successful poll result was received. Application should stop polling, and the module will continue execution and may issue new events.
-TokenResponse              | Authentication was successful, and the resulting token(s) was received. The payload of the event will contain `accessToken`, `expiresIn` and `scope`. May contain `refreshToken` and `idToken`
-TokenResponseError         | Authentication was successful, but the token request returned an error.
-SessionTimedOut            | The authentication process took too long, and timed out. The user will have to start over using `start()` method again.
-IncorrectCredentials       | The user enter wrong credentials in an `AuthenticationStep`. Show an error to the user and allow them to try again. [Invalid Input Problem](https://curity.io/docs/haapi-data-model/latest/invalid-input-problem.html)
-ProblemRepresentation      | The server returned an unexpected problem. [Problem](https://curity.io/docs/haapi-data-model/latest/problem.html)
-HaapiError                 | An unexpected problem happened. Event will have members `error` and `error_description`
+| Event Name                 | Emitted when                                                                                                                                                                                                                               |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AuthenticationStep         | An action is required by the user as part of authentication. See [Authentication Step](https://curity.io/docs/haapi-data-model/latest/authentication-step.html)                                                                            |
+| AuthenticationSelectorStep | An `AuthenticationStep` with the kind `authenticator-selector` is received. An authenticator selector screen should be be shown to the user.                                                                                               |
+| ContinueSameStep           | A screen should be shown to the user, containing some information. The only required action by the user is to accept or in some cases cancel. [Continue Same Step](https://curity.io/docs/haapi-data-model/latest/continue-same-step.html) |
+| PollingStep                | An authentication step that requires polling was received. May contain information for the user for how to proceed authentication out of band. [Polling Step](https://curity.io/docs/haapi-data-model/latest/polling-step.html)            |
+| PollingStepResult          | A poll result was received with the `status` `PENDING`. The application may show new information to the user and continue polling.                                                                                                         |
+| StopPolling                | A successful poll result was received. Application should stop polling, and the module will continue execution and may issue new events.                                                                                                   |
+| TokenResponse              | Authentication was successful, and the resulting token(s) was received. The payload of the event will contain `accessToken`, `expiresIn` and `scope`. May contain `refreshToken` and `idToken`                                             |
+| TokenResponseError         | Authentication was successful, but the token request returned an error.                                                                                                                                                                    |
+| SessionTimedOut            | The authentication process took too long, and timed out. The user will have to start over using `start()` method again.                                                                                                                    |
+| IncorrectCredentials       | The user enter wrong credentials in an `AuthenticationStep`. Show an error to the user and allow them to try again. [Invalid Input Problem](https://curity.io/docs/haapi-data-model/latest/invalid-input-problem.html)                     |
+| ProblemRepresentation      | The server returned an unexpected problem. [Problem](https://curity.io/docs/haapi-data-model/latest/problem.html)                                                                                                                          |
+| HaapiError                 | An unexpected problem happened. Event will have members `error` and `error_description`                                                                                                                                                    |
 
 ## Example implementation
 
-See <https://github.com/curityio/react-native-haapi-example> for example implementation in javascript which is mostly driven by events.
+See <https://github.com/curityio/react-native-haapi-example> for example implementation in javascript which is mostly
+driven by events.
 
 ## Development
-To deploy changes in the modules to an application without publishing a new package, a file system dependency may be used. 
-* Pack your module with: `npm pack`. This will provide a `.tgz` file containing the module. 
-* Then in your application, depend on your file using `npm install $path_to_file/react-native-haapi-module/curity-react-native-haapi-module-0.4.2.tgz --save`
+
+To deploy changes in the modules to an application without publishing a new package, a file system dependency may be
+used.
+
+* Pack your module with: `npm pack`. This will provide a `.tgz` file containing the module.
+* Then in your application, depend on your file
+  using `npm install $path_to_file/react-native-haapi-module/curity-react-native-haapi-module-0.4.2.tgz --save`
 
 ## Known limitations
 

--- a/android/src/main/java/io/curity/haapi/react/HaapiConfigurationUtil.kt
+++ b/android/src/main/java/io/curity/haapi/react/HaapiConfigurationUtil.kt
@@ -21,15 +21,18 @@ import com.facebook.react.bridge.ReactApplicationContext
 import se.curity.identityserver.haapi.android.driver.ClientAuthenticationMethodConfiguration
 import se.curity.identityserver.haapi.android.driver.KeyPairAlgorithmConfig
 import se.curity.identityserver.haapi.android.driver.TokenBoundConfiguration
-import se.curity.identityserver.haapi.android.sdk.*
+import se.curity.identityserver.haapi.android.sdk.DcrConfiguration
+import se.curity.identityserver.haapi.android.sdk.HaapiAccessorFactory
+import se.curity.identityserver.haapi.android.sdk.HaapiConfiguration
+import se.curity.identityserver.haapi.android.sdk.OAuthAuthorizationParameters
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URLConnection
-import java.time.Duration
-import javax.net.ssl.X509TrustManager
 import java.security.cert.X509Certificate
+import java.time.Duration
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
 
 object HaapiConfigurationUtil {
 
@@ -53,11 +56,11 @@ object HaapiConfigurationUtil {
             OAuthAuthorizationParameters(
                 scope = asStringOrDefault(conf, "scope", "").split(" "),
                 acrValues = asStringOrDefault(conf, "acrValues", "").split(" "),
-                extraRequestParameters = asOptionalMap(conf, "extraRequestParameters")
+                extraRequestParameters = asStringMap(conf, "extraRequestParameters")
             )
         },
         httpHeadersProvider = {
-          asOptionalMap(conf, "httpHeadersProvider")
+            asStringMap(conf, "extraHttpHeaders")
         },
         httpUrlConnectionProvider = { url ->
             val validateCertificate = conf["validateTlsCertificate"] as? Boolean? ?: true
@@ -92,8 +95,8 @@ object HaapiConfigurationUtil {
         currentTimeMillisProvider = { System.currentTimeMillis() }
     )
 
-    private fun asOptionalMap(conf: HashMap<String, Any>, parameter: String): Map<String, String> {
-      return conf[parameter] as? Map<String, String> ?: mapOf()
+    private fun asStringMap(conf: HashMap<String, Any>, parameter: String): Map<String, String> {
+        return conf[parameter] as? Map<String, String> ?: mapOf()
     }
 
     private fun asStringOrDefault(conf: HashMap<String, Any>, parameter: String, defaultValue: String): String =

--- a/android/src/main/java/io/curity/haapi/react/HaapiConfigurationUtil.kt
+++ b/android/src/main/java/io/curity/haapi/react/HaapiConfigurationUtil.kt
@@ -21,10 +21,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import se.curity.identityserver.haapi.android.driver.ClientAuthenticationMethodConfiguration
 import se.curity.identityserver.haapi.android.driver.KeyPairAlgorithmConfig
 import se.curity.identityserver.haapi.android.driver.TokenBoundConfiguration
-import se.curity.identityserver.haapi.android.sdk.DcrConfiguration
-import se.curity.identityserver.haapi.android.sdk.HaapiAccessorFactory
-import se.curity.identityserver.haapi.android.sdk.HaapiConfiguration
-import se.curity.identityserver.haapi.android.sdk.OAuthAuthorizationParameters
+import se.curity.identityserver.haapi.android.sdk.*
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URLConnection
@@ -56,10 +53,11 @@ object HaapiConfigurationUtil {
             OAuthAuthorizationParameters(
                 scope = asStringOrDefault(conf, "scope", "").split(" "),
                 acrValues = asStringOrDefault(conf, "acrValues", "").split(" "),
+                extraRequestParameters = asOptionalMap(conf, "extraRequestParameters")
             )
         },
         httpHeadersProvider = {
-            mapOf()
+          asOptionalMap(conf, "httpHeadersProvider")
         },
         httpUrlConnectionProvider = { url ->
             val validateCertificate = conf["validateTlsCertificate"] as? Boolean? ?: true
@@ -93,6 +91,10 @@ object HaapiConfigurationUtil {
         storage = SharedPreferencesStorage("token-bound-storage", reactContext),
         currentTimeMillisProvider = { System.currentTimeMillis() }
     )
+
+    private fun asOptionalMap(conf: HashMap<String, Any>, parameter: String): Map<String, String> {
+      return conf[parameter] as? Map<String, String> ?: mapOf()
+    }
 
     private fun asStringOrDefault(conf: HashMap<String, Any>, parameter: String, defaultValue: String): String =
         asOptionalString(conf, parameter) ?: defaultValue


### PR DESCRIPTION
I'm adding a generic way to support `extraRequestParameters` and `httpHeadersProvider` into `HaapiConfiguration`