### PR TITLE
Allow persistance of tokens in ios module

### DIFF
--- a/react-native-haapi-module.podspec
+++ b/react-native-haapi-module.podspec
@@ -9,10 +9,11 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "14.0" }
-  s.source       = { :git => "https://github.com/curityio/react-native-haapi-module.git"}
+  s.source       = { :git => "https://github.com/curityio/react-native-haapi-module.git", :tag => package["version"]}
+  s.swift_version = '4.2'
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   
   s.dependency "React-Core"
-  s.dependency "IdsvrHaapiSdk"
+  s.dependency "IdsvrHaapiSdk", "4.1.4"
 end


### PR DESCRIPTION
The ios module required you to call the `start` method to setup the manager objects. This makes it hard to persist tokens across restarts, since you would have to start an authentication flow to use the `refresh` method.
This PR initializes the managers lazily when needed 

The podspec is updated to pin a specific HAAPI SDK version.